### PR TITLE
Remove moment dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "eth-sig-util": "^2.5.2",
         "ethers": "^5.2.0",
         "lodash": "^4.17.15",
-        "moment": "^2.24.0",
         "query-string": "^6.9.0"
       },
       "devDependencies": {
@@ -3892,14 +3891,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -8901,11 +8892,6 @@
           }
         }
       }
-    },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "eth-sig-util": "^2.5.2",
     "ethers": "^5.2.0",
     "lodash": "^4.17.15",
-    "moment": "^2.24.0",
     "query-string": "^6.9.0"
   },
   "repository": "github:sportx-bet/sportx-js",

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,7 +1,6 @@
 import { isHexString } from "@ethersproject/bytes";
 import { BigNumber, constants, utils } from "ethers";
 import _ from "lodash";
-import moment from "moment";
 import { isBoolean } from "util";
 import { FRACTION_DENOMINATOR } from "../constants";
 import { IFillDetailsMetadata } from "../types/internal";
@@ -148,7 +147,8 @@ export function validateIRelayerMakerOrder(order: IRelayerMakerOrder) {
   if (bigNumPercentageOdds.gte(FRACTION_DENOMINATOR)) {
     return `percentageOdds must be less than ${FRACTION_DENOMINATOR.toString()}`;
   }
-  if (moment.unix(parseInt(expiry, 10)).isBefore(moment())) {
+  // What validates that expiry isn't a NaN?
+  if (parseInt(expiry, 10) < Date.now() / 1000) {
     return "expiry before current time.";
   }
   if (!isAddress(executor)) {
@@ -184,7 +184,7 @@ export function validateINewOrderSchema(order: INewOrder) {
   if (!_.isNumber(order.expiry) || order.expiry < 0) {
     return "Expiry undefined or malformed.";
   }
-  if (moment.unix(order.expiry).isBefore(moment())) {
+  if (order.expiry < Date.now() / 1000) {
     return "Expiry before current time.";
   }
   if (!isPositiveBigNumber(order.totalBetSize)) {


### PR DESCRIPTION
`moment` is 290 kb of minified javascript that is apparently used _just_ to compare two ints with `Date.now()` here.

https://bundlephobia.com/package/@sportx-bet/sportx-js@6.1.2:

<img width="1397" alt="Screenshot_20210813_220645" src="https://user-images.githubusercontent.com/291301/129407201-d2a850be-0722-44d2-b530-87250174251c.png">

(side note: lodash is also not needed here, but let's deal with `moment` for now).


Please see comment before merging, I think there is also validation lacking there.