### PR TITLE
Don't use util import

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -2,7 +2,6 @@ import { isHexString } from "@ethersproject/bytes";
 import { BigNumber, constants, utils } from "ethers";
 import _ from "lodash";
 import moment from "moment";
-import { isBoolean } from "util";
 import { FRACTION_DENOMINATOR } from "../constants";
 import { IFillDetailsMetadata } from "../types/internal";
 import {
@@ -118,6 +117,10 @@ export function validateIFillDetailsMetadata(metadata: IFillDetailsMetadata) {
     return "returning is not a string";
   }
   return "OK";
+}
+
+function isBoolean(arg: any) {
+  return typeof arg === "boolean";
 }
 
 export function validateIRelayerMakerOrder(order: IRelayerMakerOrder) {


### PR DESCRIPTION
There was only one place where `util` import was being used, and that was done to do `typeof x === 'boolean'`, which is exactly what `util.isBoolean()` does.

No reason to use `util` import in a browser-targeting package for just that IMO.