### PR TITLE
Dedupe isAddress implementation

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,4 +1,4 @@
-import { getAddress } from "@ethersproject/address";
+import { isAddress } from "@ethersproject/address";
 import { BigNumber } from "@ethersproject/bignumber";
 import { isHexString } from "@ethersproject/bytes";
 import * as constants from "@ethersproject/constants";
@@ -237,11 +237,4 @@ export function isPositiveBigNumber(object: any): boolean {
   }
 }
 
-export function isAddress(object: any) {
-  try {
-    getAddress(object);
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
+export { isAddress }


### PR DESCRIPTION
`@ethersproject/address` has literally the same function which does this:

```js
export function isAddress(address: string): boolean {
    try {
        getAddress(address);
        return true;
    } catch (error) { }
    return false;
}
```

There are differences in types, but lint passes.