### PR TITLE
Use full path imports for esm interprop

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,2 +1,2 @@
-export * from "./schema_error";
-export * from "./api_error";
+export * from "./schema_error.js";
+export * from "./api_error.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,15 +8,15 @@ export {
   Tokens,
   TOKEN_ADDRESSES,
   TOKEN_TRANSFER_PROXY_ADDRESS
-} from "./constants";
-export * from "./errors";
-export * from "./sportx";
-export * from "./types/internal";
-export * from "./types/relayer";
+} from "./constants.js";
+export * from "./errors/index.js";
+export * from "./sportx.js";
+export * from "./types/internal.js";
+export * from "./types/relayer.js";
 export {
   convertFromAPIPercentageOdds,
   convertToAPIPercentageOdds,
   convertToDisplayAmount,
   convertToTakerPayAmount,
   convertToTrueTokenAmount
-} from "./utils/convert";
+} from "./utils/convert.js";

--- a/src/sportx.ts
+++ b/src/sportx.ts
@@ -24,16 +24,16 @@ import {
   SidechainNetworks,
   TOKEN_ADDRESSES,
   TOKEN_TRANSFER_PROXY_ADDRESS
-} from "./constants";
-import { APIError } from "./errors/api_error";
-import { APISchemaError } from "./errors/schema_error";
+} from "./constants.js";
+import { APIError } from "./errors/api_error.js";
+import { APISchemaError } from "./errors/schema_error.js";
 import {
   IApproveSpenderPayload,
   IBaseTokenWrappers,
   ICancelDetails,
   IFillDetails,
   IFillDetailsMetadata
-} from "./types/internal";
+} from "./types/internal.js";
 import {
   IActiveLeague,
   IDetailedRelayerMakerOrder,
@@ -53,17 +53,17 @@ import {
   ISignedRelayerMakerOrder,
   ISport,
   ITradesResponse
-} from "./types/relayer";
-import { convertToContractOrder } from "./utils/convert";
-import { tryParseJson } from "./utils/misc";
-import { getSidechainNetwork } from "./utils/networks";
+} from "./types/relayer.js";
+import { convertToContractOrder } from "./utils/convert.js";
+import { tryParseJson } from "./utils/misc.js";
+import { getSidechainNetwork } from "./utils/networks.js";
 import {
   getCancelOrderEIP712Payload,
   getFillOrderEIP712Payload,
   getMaticEip712Payload,
   getOrderHash,
   getOrderSignature
-} from "./utils/signing";
+} from "./utils/signing.js";
 import {
   isAddress,
   isPositiveBigNumber,
@@ -72,7 +72,7 @@ import {
   validateIGetTradesRequest,
   validateINewOrderSchema,
   validateISignedRelayerMakerOrder
-} from "./utils/validation";
+} from "./utils/validation.js";
 
 export interface ISportX {
   init(): Promise<void>;

--- a/src/types/relayer.ts
+++ b/src/types/relayer.ts
@@ -1,4 +1,4 @@
-import { IApproveSpenderPayload, ICancelDetails } from "./internal";
+import { IApproveSpenderPayload, ICancelDetails } from "./internal.js";
 
 export interface IRelayerMakerOrder {
   marketHash: string;

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -5,9 +5,9 @@ import {
   FRACTION_DENOMINATOR,
   PERCENTAGE_PRECISION_EXPONENT,
   TokenDecimalMapping
-} from "../constants";
-import { IContractOrder } from "../types/internal";
-import { IRelayerMakerOrder } from "../types/relayer";
+} from "../constants.js";
+import { IContractOrder } from "../types/internal.js";
+import { IRelayerMakerOrder } from "../types/relayer.js";
 
 export function convertToAPIPercentageOdds(decimal: number): EthBigNumber {
   if (decimal < 0 || decimal > 1) {

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -1,6 +1,6 @@
 import { BigNumber as EthBigNumber } from "@ethersproject/bignumber";
 import { formatUnits, parseUnits } from "@ethersproject/units";
-import { BigNumber } from "bignumber.js";
+import BigNumber from "bignumber.js";
 import {
   FRACTION_DENOMINATOR,
   PERCENTAGE_PRECISION_EXPONENT,

--- a/src/utils/networks.ts
+++ b/src/utils/networks.ts
@@ -1,4 +1,4 @@
-import { Environments, PublicNetworks, SidechainNetworks } from "../constants";
+import { Environments, PublicNetworks, SidechainNetworks } from "../constants.js";
 
 export function getMainchainNetwork(environment: Environments) {
   switch (environment) {

--- a/src/utils/signing.ts
+++ b/src/utils/signing.ts
@@ -5,9 +5,9 @@ import {
   ICancelDetails,
   IContractOrder,
   IFillDetails
-} from "../types/internal";
-import { IRelayerMakerOrder } from "../types/relayer";
-import { convertToContractOrder } from "./convert";
+} from "../types/internal.js";
+import { IRelayerMakerOrder } from "../types/relayer.js";
+import { convertToContractOrder } from "./convert.js";
 
 export async function getOrderSignature(
   order: IRelayerMakerOrder,

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -2,16 +2,16 @@ import { isAddress } from "@ethersproject/address";
 import { BigNumber } from "@ethersproject/bignumber";
 import { isHexString } from "@ethersproject/bytes";
 import { Zero } from "@ethersproject/constants";
-import { FRACTION_DENOMINATOR } from "../constants";
-import { IFillDetailsMetadata } from "../types/internal";
+import { FRACTION_DENOMINATOR } from "../constants.js";
+import { IFillDetailsMetadata } from "../types/internal.js";
 import {
   IGetTradesRequest,
   INewOrder,
   IPendingBetsRequest,
   IRelayerMakerOrder,
   ISignedRelayerMakerOrder
-} from "../types/relayer";
-import { convertToAPIPercentageOdds } from "./convert";
+} from "../types/relayer.js";
+import { convertToAPIPercentageOdds } from "./convert.js";
 
 export function validateIGetPendingBetsRequest(payload: IPendingBetsRequest) {
   const { bettor, startDate, endDate, fillHash, baseToken } = payload;

--- a/test/sportx.test.ts
+++ b/test/sportx.test.ts
@@ -3,20 +3,20 @@ import { parseUnits } from "@ethersproject/units";
 import { Wallet } from "@ethersproject/wallet";
 import { expect } from "chai";
 import "mocha";
-import { INewOrder, IPendingBetsRequest } from "../src";
+import { INewOrder, IPendingBetsRequest } from "../src/index.js";
 import {
   DEFAULT_MATIC_RPL_URLS,
   Environments,
   TOKEN_ADDRESSES,
   Tokens
-} from "../src/constants";
-import { ISportX, newSportX } from "../src/sportx";
+} from "../src/constants.js";
+import { ISportX, newSportX } from "../src/sportx.js";
 import {
   convertFromAPIPercentageOdds,
   convertToAPIPercentageOdds,
   convertToTrueTokenAmount
-} from "../src/utils/convert";
-import { getSidechainNetwork } from "../src/utils/networks";
+} from "../src/utils/convert.js";
+import { getSidechainNetwork } from "../src/utils/networks.js";
 
 // tslint:disable no-string-literal
 


### PR DESCRIPTION
Also fix bignumber.js import.

Using full path `*.js` imports is the recommended approach for ts code.

* Neither browsers or Node.js in ESM mode support importing paths without extensions.
* The correct extension for importing TypeScript files is `.js`.
   Otherwise TS will error with `error TS2691: An import path cannot end with a '.ts' extension. Consider importing './{path}.js' instead.`

Refs: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#how-can-i-make-my-typescript-project-output-esm


Notes:
 * This doesn't set `type: module` in the top-level package and doesn't affect anything else yet.
 * This doesn't deal with json imports yet.

As a demo of what is the aim here, e.g. [this branch](https://github.com/ExodusMovement/sportx-js/commits/exodus) has the other necessary changes (that are affecting less code and more the package config) to allow compiling this module to the code that could be used directly from Node.js without bundling.